### PR TITLE
SASL can now be effectively enforced.

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -282,6 +282,9 @@ def registerNetwork(name, password='', ssl=False, sasl_username='',
     registerGlobalValue(sasl, 'password', registry.String(sasl_password,
         """Determines what SASL password will be used on %s.""" \
         % (name,), private=True))
+    registerGlobalValue(sasl, 'required',
+        registry.Boolean(False, """If set and SASL auth fails, bot will refuse to continue.
+        Useful for Freenode for cloak-at-connect-or-fail.""", showDefault=True, setDefault=True, private=True))
     return network
 
 # Let's fill our networks.

--- a/src/drivers/Socket.py
+++ b/src/drivers/Socket.py
@@ -168,6 +168,11 @@ class SocketDriver(drivers.IrcDriver, drivers.ServersMixin):
         else:
             drivers.log.debug('Not resetting %s.', self.irc)
         server = self._getNextServer()
+
+        if self.networkGroup.get('sasl').required() and not self.networkGroup.get('ssl').value:
+            drivers.log.error('SASL required but it is crazy to use it without SSL.')
+            return
+
         drivers.log.connect(self.currentServer)
         try:
             self.conn = utils.net.getSocket(server[0])


### PR DESCRIPTION
Patch disconnects prior to the CAP END stage thus (reportedly) disabling failed SASL auth accidental decloak in the event SASLServ is not available to authenticate.

SASL authentication guarantees vhost-enabled user introduction to the server (at least for the atheme-using IRCd out there like charybdis.)
